### PR TITLE
Remove `#[flux::generics]`

### DIFF
--- a/flux_support/src/extern_specs/iter.rs
+++ b/flux_support/src/extern_specs/iter.rs
@@ -11,7 +11,6 @@ struct Iter<'a, T>;
 // struct Enumerate<I>;
 
 // #[flux_rs::extern_spec(std::iter)]
-// #[flux_rs::generics(Self as base)]
 // #[flux_rs::assoc(fn done(self: Self) -> bool )]
 // #[flux_rs::assoc(fn step(self: Self, other: Self) -> bool )]
 // trait Iterator {
@@ -25,7 +24,6 @@ struct Iter<'a, T>;
 // }
 
 // #[flux_rs::extern_spec(std::slice)]
-// #[flux_rs::generics(T as base)]
 // #[flux_rs::assoc(fn done(x: Iter<T>) -> bool { x.idx >= x.len })]
 // #[flux_rs::assoc(fn step(x: Iter<T>, y: Iter<T>) -> bool { x.idx + 1 == y.idx && x.len == y.len})]
 // impl<'a, T> Iterator for Iter<'a, T> {
@@ -34,7 +32,6 @@ struct Iter<'a, T>;
 // }
 
 // #[flux_rs::extern_spec(std::iter)]
-// #[flux_rs::generics(I as base)]
 // #[flux_rs::assoc(fn done(x: Enumerate<I>) -> bool { <I as Iterator>::done(x.inner)})]
 // #[flux_rs::assoc(fn step(x: Enumerate<I>, y: Enumerate<I>) -> bool { <I as Iterator>::step(x.inner, y.inner)})]
 // impl<I: Iterator> Iterator for Enumerate<I> {

--- a/flux_support/src/extern_specs/range.rs
+++ b/flux_support/src/extern_specs/range.rs
@@ -4,7 +4,6 @@ use core::ops::Bound;
 use core::ops::{Range, RangeBounds};
 
 #[flux_rs::extern_spec]
-#[generics(T as base)]
 #[flux_rs::refined_by(included: bool, unbounded: bool)]
 enum Bound<T> {
     #[variant((T) -> Bound<T>[true, false])]
@@ -29,7 +28,6 @@ struct Range<Idx> {
 }
 
 #[flux_rs::extern_spec(core::ops)]
-#[generics(Self as base, T as base, U as base)]
 #[flux_rs::assoc(fn start(self: Self) -> T)]
 #[flux_rs::assoc(fn end(self: Self) -> T)]
 trait RangeBounds<T> {
@@ -57,7 +55,6 @@ trait RangeBounds<T> {
 }
 
 #[flux_rs::extern_spec(core::ops)]
-#[generics(T as base)]
 #[flux_rs::assoc(fn start(self: Range<T>) -> T { self.end })]
 #[flux_rs::assoc(fn end(self: Range<T>) -> T { self.end })]
 impl<T> RangeBounds<T> for Range<T> {

--- a/flux_support/src/extern_specs/slice.rs
+++ b/flux_support/src/extern_specs/slice.rs
@@ -2,7 +2,6 @@
 use core::slice::{self, Iter, SliceIndex};
 
 // #[flux_rs::extern_spec]
-// #[generics(Self as base, T as base)]
 // #[assoc(fn in_bounds(idx: Self, v: T) -> bool)]
 // trait SliceIndex<T>
 // where
@@ -22,7 +21,6 @@ impl<T> [T] {
     #[flux_rs::sig(fn(&[T][@len]) -> Iter<T>[0, len])]
     fn iter(v: &[T]) -> Iter<'_, T>;
 
-    // #[flux_rs::generics(I as base)]
     // #[flux_rs::sig(fn(&[T][@len], I[@idx]) -> Option<_>[<I as SliceIndex<[T]>>::in_bounds(idx, len)])]
     // fn get(&self, index: I) -> Option<&<I as SliceIndex<[T]>>::Output>;
 }


### PR DESCRIPTION
The attribute has been a no-op for a long time